### PR TITLE
Fix overflow on detail screen of extension

### DIFF
--- a/FrontEnd/src/components/css/style.css
+++ b/FrontEnd/src/components/css/style.css
@@ -19,3 +19,12 @@
     align-items: center;
     justify-content: center;
 }
+
+.table {
+    table-layout: fixed;
+}
+
+.table__url {
+    word-wrap: break-word;
+    word-break: break-all;
+}

--- a/FrontEnd/src/pages/Extensions/ExtensionDetailScreen.tsx
+++ b/FrontEnd/src/pages/Extensions/ExtensionDetailScreen.tsx
@@ -1,7 +1,6 @@
 import { useExtension } from '../../hooks/useExtension.ts'
-import { Container, Table } from 'react-bootstrap'
+import { Col, Container, Row, Table } from 'react-bootstrap'
 import { useParams } from 'react-router-dom'
-import { Version } from '../../types'
 
 export function ExtensionDetailScreen() {
 
@@ -27,40 +26,44 @@ export function ExtensionDetailScreen() {
 
   return (
     <Container className="my-4">
-      <h2>Extension: {extensionDetails.name}</h2>
-      <p>Area: {extensionDetails.area}</p>
-      <p>Type: {extensionDetails.type}</p>
-      <p>Language(s): {extensionDetails.languages}</p>
-      <p>{extensionDetails.description}</p>
-      {Object.entries(extensionDetails.properties ?? {}).length > 0 && (
-        <>
-          <h3>Extra Properties</h3>
-          <ul>
-            {Object.entries(extensionDetails.properties).map(([key, value]) => (
-              <li key={key}>
-                <strong>{key}: </strong> {value}
-              </li>
+      <Row>
+        <Col className="col-12">
+          <h2>Extension: {extensionDetails.name}</h2>
+          <p>Area: {extensionDetails.area}</p>
+          <p>Type: {extensionDetails.type}</p>
+          <p>Language(s): {extensionDetails.languages}</p>
+          <p>{extensionDetails.description}</p>
+          {Object.entries(extensionDetails.properties ?? {}).length > 0 && (
+            <>
+              <h3>Extra Properties</h3>
+              <ul>
+                {Object.entries(extensionDetails.properties).map(([key, value]) => (
+                  <li key={key}>
+                    <strong>{key}: </strong> {value}
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+          <h3>Version history</h3>
+          <Table striped bordered hover>
+            <thead>
+            <tr>
+              <th className={'col col-10'}>URL</th>
+              <th className={'col col-2'}>Version</th>
+            </tr>
+            </thead>
+            <tbody>
+            {extensionDetails.versions.map((version) => (
+              <tr key={version.url}>
+                <td className="table__url">{version.url}</td>
+                <td>{version.version}</td>
+              </tr>
             ))}
-          </ul>
-        </>
-      )}
-      <h3>Version history</h3>
-      <Table striped bordered hover>
-        <thead>
-        <tr>
-          <th>URL</th>
-          <th>Version</th>
-        </tr>
-        </thead>
-        <tbody>
-        {extensionDetails.versions.map((version: Version) => (
-          <tr key={version.url}>
-            <td>{version.url}</td>
-            <td>{version.version}</td>
-          </tr>
-        ))}
-        </tbody>
-      </Table>
+            </tbody>
+          </Table>
+        </Col>
+      </Row>
     </Container>
   )
 }

--- a/FrontEnd/src/pages/Extensions/ExtensionDetailScreen.tsx
+++ b/FrontEnd/src/pages/Extensions/ExtensionDetailScreen.tsx
@@ -49,7 +49,7 @@ export function ExtensionDetailScreen() {
           <Table striped bordered hover>
             <thead>
             <tr>
-              <th className={'col col-10'}>URL</th>
+              <th className={'col col-9'}>URL</th>
               <th className={'col col-2'}>Version</th>
             </tr>
             </thead>


### PR DESCRIPTION
### 🛠 Changes being made
- Added the css and classnames to get right sizing of the version table

### ✨ What's the context?
Layout differs on edge and safari.

### 🧪 Testing
Only layout changes.

### 📸 Screenshots (optional)
![image](https://github.com/BauwenDR/osta-marketplace/assets/101172722/d3df0a77-655c-496e-a733-fb2e783523f4)

### 🏎 Quality check
- [x] Are there any errors, console logs, debuggers or leftover code in your changes?
- [x] Did you update the documentation for your code?

### 🐛 Linked issues

- Closes #17 
