### PR TITLE
Links in documentation still point to wrong repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ## Contributing
-Anyone is welcome to open [issues](https://github.com/BauwenDR/osta-marketplace/issues) and/or pull-requests for bugfixes, feature-requests and/or ideas. If unsure where to start we encourage you to open a [discussion](https://github.com/BauwenDR/osta-marketplace/discussions) topic first.
+Anyone is welcome to open [issues](https://github.com/OSTA-group/osta-marketplace/issues) and/or pull-requests for bugfixes, feature-requests and/or ideas. If unsure where to start we encourage you to open a [discussion](https://github.com/OSTA-group/osta-marketplace/discussions) topic first.
 
 ## How to build
 ### Required programs
@@ -32,7 +32,7 @@ Before you start coding, follow these steps:
   - Commit your changes with clear and concise messages.
 
 ### 3. Pull request
-  - Follow the [checklist](https://github.com/BauwenDR/osta-marketplace/blob/main/.github/pull_request_template.md) to make sure that you're 100% done.
+  - Follow the [checklist](https://github.com/OSTA-group/osta-marketplace/blob/main/.github/pull_request_template.md) to make sure that you're 100% done.
   - Once your changes are ready, open a pull request (PR) to merge your branch into to main repository
 
 Happy coding! 🚀

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OSTA Marketplace
-The OSTA Marketplace is a website that provides extensions for the [Open Source Travel Application](https://github.com/BauwenDR/osta). Extensions are synchronized with the json file from [this](https://github.com/BauwenDR/osta-extensions) project.
+The OSTA Marketplace is a website that provides extensions for the [Open Source Travel Application](https://github.com/OSTA-group/osta). Extensions are synchronized with the json file from [this](https://github.com/OSTA-group/osta-extensions) project.
 
 ## Documentation
-You can find the working of our services [here](https://github.com/BauwenDR/osta/blob/main/.github/OSTA-Technical-Documentation.pdf).
+You can find the working of our services [here](https://github.com/OSTA-group/osta/wiki/TechnicalDocumentation).
 
 ## Contributing
 See [contributing](https://github.com/BauwenDR/osta-marketplace/blob/main/.github/CONTRIBUTING.md).


### PR DESCRIPTION
### 🛠 Changes being made
Some links in markdown files still pointed to the old repo locations.

### 🐛 Linked issues
- Closes #26 